### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ async function handler(req, res) {
   const format = query.format || parseAccept(req);
   let tag = (
     query.tag ||
-    decodeURIComponent(pathname.substr(1)) ||
+    decodeURIComponent(pathname.slice(1)) ||
     '*'
   ).toLowerCase();
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.